### PR TITLE
Revert "Bump lodash from 4.17.1 to 4.17.2"

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -5,13 +5,13 @@
     "packages": {
         "": {
             "dependencies": {
-                "lodash": "^4.17.2"
+                "lodash": "^4.17.1"
             }
         },
         "node_modules/lodash": {
-            "version": "4.17.2",
-            "resolved": "https://jfrogghdemo.jfrog.io/artifactory/api/npm/db-dependabot-local/lodash-4.17.2.tgz",
-            "integrity": "sha512-8mozooKYfrbhO6eMFCjiieXZalOKHpwENKTqMn/g0TrH1j4MLw8qwivmVwfcX5/+3LQJmXAWRXWhWUL+COdYNg==",
+            "version": "4.17.1",
+            "resolved": "https://jfrogghdemo.jfrog.io/artifactory/api/npm/dependabot-npm/lodash-4.17.1.tgz",
+            "integrity": "sha512-TU8moLfqGOx1RJogO9uU2d90q0L5J/1g/i4fkdB5ZmQ5qsjwVnCvg5XWuiwqqPNnyBQlQp8ukd9ADTY27dGsiQ==",
             "license": "MIT"
         }
     }

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
     "dependencies": {
-        "lodash": "^4.17.2"
+        "lodash": "^4.17.1"
     }
 }


### PR DESCRIPTION
Reverts dsp-testing/npm-private-registry-success#4